### PR TITLE
Add indices for the Eb NewReal2

### DIFF
--- a/NewReal2-Eb.csv
+++ b/NewReal2-Eb.csv
@@ -1,0 +1,229 @@
+Afro-Centric,8,8
+After The Rain,9,9
+After You've Gone,10,10
+Ain't Misbehavin',11,11
+Along Came Betty,12,13
+ASA,14,14
+Avance,15,16
+Baby It's Cold Outside,17,18
+Baja Bajo,19,20
+Bass Blues,21,21
+Beauty And The Beast,22,22
+Bessie's Blues,23,23
+Black And Blue,24,24
+Black Coffee,25,26
+Blues For Alice,27,27
+Blues For Yna Yna,28,29
+Body And Soul,30,31
+Bolivia,32,32
+Boy Next Door, The,33,33
+Bye Bye Blackbird,34,35
+Café,36,37
+Capim,38,39
+Casa Forte,40,41
+Central Park West,42,43
+Charmed Circle,44,45
+Cherokee,46,46
+Child Is Born,47,47
+Choices,48,49
+Chromazone,50,51
+Clockwise,52,52
+Cold Duck Time,53,53
+Criss Cross,54,55
+Day By Day,56,56
+Dear Lord,57,58
+Dee Song,59,60
+Delgado,61,61
+Detour Ahead,62,62
+Devil May Care,63,64
+Django,65,66
+Doce Presenca,67,68
+Dogs In The Wine Shop,69,70
+Don't Forget The Poet,71,72
+Duke, The,73,74
+Ecaroh,75,76
+Ecaroh (Harmony),77,78
+Equinox,79,79
+Escher Sketch,80,82
+Eternal Child,83,84
+Exactly Like You,85,85
+Expression,86,86
+Falling Grace,87,87
+Filthy Mcnasty,88,89
+Five Hundred Miles High,90,90
+Flamingo,91,91
+Fly Me To The Moon,92,92
+Forever,93,94
+Freedom Jazz Dance,95,95
+Friday Night At The Cadillac Club,96,97
+Friends,98,98
+Geraldine,99,100
+Gertrude's Bounce,101,102
+Get Happy,103,104
+Giant Steps,105,105
+Got A Match,106,106
+Gregory Is Here,107,107
+Gregory Is Here (Harmony),108,108
+Growing,109,109
+Harlem Nocturne,110,111
+Hi-Fly,112,113
+Hi-Fly (Harmony),114,115
+Honeysuckle Rose,116,116
+Horace Scope,117,118
+I Believe In You,119,120
+I Hadn't Anyone Till You,121,121
+I Thought About You,122,123
+I'll Be Around (arr. Grusin),124,125
+I'll Be Around,126,126
+I'll Get By,127,127
+Ill Wind,128,128
+Illuminados,129,129
+I'm Glad There Is You,130,130
+Impressions,131,131
+In The Wee Small Hours Of The Morning,132,132
+In Your Own Sweet Way,133,134
+Isfahan,135,135
+It Don't Mean A Thing (If It Ain't Got That Swing),136,136
+It's Only A Paper Moon,137,137
+It's the Talk Of The Town,138,139
+It's You,140,141
+I've Got The World On A String,142,142
+I've Got Your Number,143,144
+I've Never Been In Love Before,145,145
+Jacob's Ladder,146,147
+Jordu,148,149
+Juntos,150,151
+Killer Joe,152,152
+Let's Fall In Love,153,153
+Like A Lover,154,155
+Like Father Like Son,156,157
+Like Sonny,158,159
+Lisa,160,160
+Little Wind,161,162
+Loose Ends,163,164
+Loxodrome,165,165
+Lullaby Of The Leaves,166,166
+Mahjong,167,167
+Manha De Carneval,168,169
+"Masquerade Is Over, The",170,171
+Mean To Me,172,172
+Memories Of You,173,173
+Midland,174,175
+Mine Is Yours,176,177
+Mo' Joe,178,178
+Mo' Joe (Harmony),179,180
+Moment's Notice,181,182
+Mood Indigo,183,183
+Moonrays,184,187
+Moontide,188,189
+Moontide (Harmony),190,191
+More Love,192,193
+More Love (Counter-melody),194,195
+Morning Sprite,196,197
+Mozambique,198,199
+Mr. P.C.,200,200
+My Ship,201,202
+Naima,203,203
+Napanoch,204,205
+"Natives Are Restless Tonight, The",206,206
+"Natives Are Restless Tonight, The (Harmony)",207,207
+Natural Selection,208,208
+"Necessary Blonde, The",209,210
+Never Alone,211,212
+Never Will I Marry,213,214
+Nica's Dream,215,216
+Nica's Dream (Harmony),217,218
+Night Dreamer,219,219
+"Nightingale Sang In Berkeley Square, A",220,221
+Nightmood (Leinbra),222,223
+Nutville,224,225
+Nutville (Harmony),226,227
+Ode To Tee Doo Da Day,228,229
+Ole,230,230
+On The Sunny Side Of The Street,231,231
+Once In A While,232,232
+Peace,233,233
+Peep,234,235
+Perdido,236,236
+Peri's Scope,237,237
+Power Play,238,239
+Promise, The,240,240
+Quicksilver,241,242
+Quiet Girl,243,244
+Quiet Place, A,245,256
+Rain Waltz,247,248
+Remember Hymn,249,249
+Rockin' Chair,250,250
+Rosetta,251,251
+Sailing At Night,252,253
+Sea Journey,254,255
+Senor Blues,256,257
+September Song,258,258
+Seven Steps To Heaven,259,260
+Silver's Serenade,261,261
+Sing Me Softly Of The Blues,262,262
+Skippy-Ing,263,264
+So Many Stars,265,266
+Some Other Blues,267,267
+Someone To Light Up My Life,268,269
+Song For My Father,270,270
+Sophisticated Lady,271,272
+Spain,273,274
+Spring Can Really Hang You Up The Most,275,276
+Stablemates,277,277
+"Star-Crossed Lovers, The",278,278
+Stardust,279,280
+Stargazer,281,282
+Still,283,283
+Story Line,284,285
+Strollin',286,287
+Strollin' (Harmony),288,288
+Summer In Central Park,289,289
+Sweet And Lovely,290,290
+T.B.C. (Terminal Baggage Claim),291,292
+That's All,293,294
+Them There Eyes,295,295
+There Is No Greater Love,296,296
+Three Hearts Dancing,297,298
+Three Little Words,299,299
+Till There Was You,300,300
+Time Marches On,301,301
+Time Remembered,302,302
+Time Track,303,304
+Togetherness,305,305
+Tristeza,306,306
+Truth,307,308
+Tunji,309,309
+Tunnel Vision,310,311
+Turn Out The Stars,312,312
+26-2,313,313
+Unforgettable,314,314
+Unless It's You (Orbit),315,315
+Veils,316,316
+Velho Plano,317,318
+Wabash III,319,320
+Waltse For Dave,321,322
+What A Difference A Day Made,323,323
+What A Little Moonlight Can Do,324,325
+When All Is Said And Done,326,326
+Whenever Your Heart Want's To Sing,327,328
+While We're Young,329,330
+Whisper Not,331,332
+Will You Say You Will,333,333
+Will You Still Be Mine,334,335
+Willow,336,337
+Wind Sprint,338,339
+Windows,340,340
+Wise One,341,342
+Woody'n You,343,343
+Words,344,346
+You Fascinate Me So,347,348
+You're Everything,349,350
+You're Everything (Instrumental),351,352
+You're My Everything,353,353
+"Joint Is Jumpin', The",355,356
+More Than You Know,357,358
+No Moon At All,359,359
+Without A Song,360,361
+Wrap Your Troubles In Dreams,362,363
+You Say You Care,364,365

--- a/NewReal2.csv
+++ b/NewReal2.csv
@@ -40,7 +40,7 @@ Dee Song,75,77
 Delgado,78,78
 photo of Scott Lefaro,79,79
 Detour Ahead,80,80
-Devil May Cape,81,82
+Devil May Care,81,82
 Django,83,84
 Doce Presenca,85,86
 Dogs In The Wine Shop,87,88
@@ -76,12 +76,12 @@ Harlem Nocturne,139,140
 Hi-Fly,141,144
 photo of Art Blakey,145,145
 Honeysuckle Rose,146,146
-Horacescope,147,148
+Horace Scope,147,148
 I Believe In You,149,150
 photo of Enrico Pieranunzi,151,151
 I Hadn't Anyone Till You,152,152
 I Thought About You,153,156
-I'll Be Around,157,158
+I'll Be Around (arr. Grusin),157,158
 I'll Be Around,159,159
 I'll Get By,160,160
 photo of Billie Holiday,161,161
@@ -96,7 +96,7 @@ photo of Johnny Hodges,171,171
 Isfahan,172,172
 It Don't Mean A Thing (If It Ain't Got That Swing),173,173
 It's Only A Paper Moon,174,174
-It's Tim Talk Of The Town,175,176
+It's the Talk Of The Town,175,176
 It's You,177,178
 photo of Billy Childs,179,179
 I've Got The World On A String,180,180
@@ -205,11 +205,11 @@ Them There Eyes,377,377
 There Is No Greater Love,378,378
 Three Hearts Dancing,379,384
 Three Little Words,385,385
-Til There Was You,386,386
+Till There Was You,386,386
 Time Marches On,387,388
 photo of Bill Evans,389,389
 Time Remembered,390,390
-Time Tracks,391,394
+Time Track,391,394
 Togetherness,395,396
 "photo of Ray Brown, Oscar Peterson & Herb Ellis",397,397
 Tristeza,398,398
@@ -232,7 +232,7 @@ When All Is Said And Done,425,426
 Whenever Your Heart Want's To Sing,427,430
 While We're Young,431,432
 Whisper Not,433,434
-Well You Say You Will,435,436
+Will You Say You Will,435,436
 Will You Still Be Mine,437,438
 Willow,439,440
 Wind Sprint,441,442


### PR DESCRIPTION
The Eb version does not include the pictures from the C version, but
does have extra harmony parts for some tunes.

Fix some minor errors in the C version to match the song titles from the PDF.