### PR TITLE
Add GH:DThompson55/FakeBookIndex alternative source

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Finally, UNIX line endings are used, rather than MS-DOS / Windows-style
 
 ## Alternative sources of indices
 
+- https://github.com/DThompson55/FakeBookIndex
 - https://git.zx2c4.com/realbook-splitter/tree/listing.txt
 - https://www.seventhstring.com/fbi/aboutfbi.html
 - https://github.com/mikeln/musicindex


### PR DESCRIPTION
As title, I'm just adding more alternatives. This one lacks the transposing instruments