### PR TITLE
Misc fixes to Library.csv

### DIFF
--- a/Library.csv
+++ b/Library.csv
@@ -4,7 +4,7 @@ Boo Boo Be Doop,6,6
 "Dandy Line, A",7,7
 "Night In Tunesia, A",7,7
 An Oscar For Treadwell,8,8
-Batter Up,9,9
+Batter Up,9,10
 Bunko,10,10
 Band Aid,11,11
 Barbados,11,11

--- a/Library.csv
+++ b/Library.csv
@@ -1,322 +1,327 @@
 Algo Bueno,5,5
-Au Privave,5,5
+Au Privave,5,6
 Boo Boo Be Doop,6,6
 "Dandy Line, A",7,7
-"Night In Tunesia, A",7,7
+"Night In Tunesia, A",7,8
 An Oscar For Treadwell,8,8
 Batter Up,9,10
 Bunko,10,10
 Band Aid,11,11
-Barbados,11,11
+Barbados,11,12
 Air Conditioning,12,12
 Bea's Flat,12,12
 Bark For Barksdale,13,13
-Billie's Bounce,13,13
+Billie's Bounce,13,14
 Bird Feathers,14,14
 Bloomdido,14,14
 Bernie's Tune,15,15
-Bockhanal,15,15
+Bockhanal,15,16
 Bottoms Up,16,16
 Boplicity,17,17
-Bouncing With Bud,17,17
-Fifty Second Street Theme,17,17
+Bouncing With Bud,17,18
+# Fifty Second Street Theme,17,17
 Bud's Blues,18,18
-Visa,18,18
+#Visa,18,18
 Brown Gold,19,19
-Budo,19,19
+Budo,19,20
 Bud's Bubble,20,20
 Bunny,21,21
-Buzzy,21,21
+Buzzy,21,22
 Casa De Luz,22,22
 Cheryl,22,22
-"Ballad, A",23,23
+"Ballad, A",23,24
 Confirmation,24,24
 Back Home Blues,25,25
 Bluebird,25,25
-Blues For Alice,25,25
+Blues For Alice,25,26
 Bounce,26,26
 Bulldog Blues,27,27
-Cairo,27,27
+Cairo,27,28
 Cone Pone,28,28
 "Champ, The",29,29
-"Chase, The",29,29
+"Chase, The",29,30
 Contours,30,30
-Cool Mix,31,31
+Cool Mix,31,32
 Cool,31,31
 Dear Old Stockholm,32,32
 Basie Eyes,33,33
-Cohn My Way,33,33
-Daa Houd,34,34
-Diablo's Dance,35,35
+Cohn My Way,33,34
+Daahoud,34,34
+Diablo's Dance,35,36
 Didi,36,36
 Cool Blues,37,37
+Donna,37,37
 Donna Lee,38,38
 Dexterity,39,39
-Dizzy Atmosphere,39,39
+Dizzy Atmosphere,39,40
 Early Autumn,40,40
 Breakfast With Joe,41,41
-Delilah,41,41
-D'Jango,42,42
+Delilah,41,42
+Django,42,42
 Dot's Groovy,43,43
-Doxy,43,43
+Doxy,43,44
 "Fruit, The",44,44
 Early Spring,45,45
-Eb Pob,45,45
+Eb Pob,45,46
 Elevation,46,46
 Eleven Sixty,46,46
 Everywhere,47,47
 Feather Merchant,48,48
 Figure 8,48,48
 Emanon,49,49
-Ergo,49,49
+Ergo,49,50
 For Stompers Only,50,50
 Godchild,50,50
 Five Brothers,51,51
-Four Brothers,51,51
+Four Brothers,51,52
 Four Mothers,52,52
 Flash,53,53
-Four,53,53
-Bags' Groove,54,54
+Four,53,54
+# Bags' Groove,54,54
 Freckles,54,54
 Good Bait,55,55
-Half Nelson,55,55
+Half Nelson,55,56
 Happy Little Sunbeam,56,56
 "Half Dozens, The",57,57
-Hallucinations,57,57
+Hallucinations,57,58
 In The Nick Of Time,58,58
 Groovin' High,59,59
+Headline,59,60
 Herbstone,60,60
 Hershey Bar,61,61
-Indian Club,61,61
+Indian Club,61,62
 In The Mode,62,62
-I Know Don't Know How,63,63
-Memo's Blues,63,63
+I Know Don't Know How,63,64
+Hamp's Blues,63,63
 Joy Spring,64,64
 Inside Out,65,65
-Jumping With Symphony Sid,65,65
+Jumping With Symphony Sid,65,66
 Just A Few,66,66
 H. And J.,67,67
-It's Sand Man,67,67
+"It's Sand, Man",67,68
 Jasmin,68,68
-Jazzbo's Haunt,69,69
-Je Ne Sais Pas,69,69
+Jazzbo's Jaunt,69,69
+Je Ne Sais Pas,69,70
 Jordu,70,70
 Jeru,71,71
 Jive At Five,71,72
+Leap Here,72,72
 Jump For Me,73,73
-Lady McGowan's Dream,73,73
+Lady McGowan's Dream,73,74
 "Little Duet, A",74,74
 La Mucura,75,75
 Lady Bird,75,75
 Left Bank,76,76
 Limelight,77,77
-Line For Lyons,77,77
+Line For Lyons,77,78
 Little Willie Leaps,78,78
 Lee,79,79
-Mambo Del Crow,79,79
+Mambo Del Crow,79,80
 May-Rey,80,80
 Lullaby Of Birdland,81,81
-Maid In Mexico,81,81
+Maid In Mexico,81,82
 Midnight Sun,82,82
 Motion,83,83
-Nick's Knacks,83,83
+Nick's Knacks,83,84
 Night Life,84,84
 K. C. Blues,85,85
 Mellophone Mambo,85,85
-Minor Blues,85,85
+Minor Blues,85,86
 Opus De Funk,86,86
 "Preacher, The",86,86
-Mohawk,87,87
+Mohawk,87,88
 Simbah,87,87
 Move,88,88
 Morpo,89,89
-Motel,89,89
+Motel,89,90
 My Little Suede Shoes,90,90
 Prince Albert,91,91
 Quicksilver,91,92
 Nights At The Turntable,93,93
-No Ties,93,93
+No Ties,93,94
 Now Is The Time,94,94
 O Go Mo,95,95
-Onion Bottom,95,95
+Onion Bottom,95,96
 Ontet,96,96
 Open Country,97,97
-Ornithology,97,97
+Ornithology,97,98
 Out Of Somewhere,98,98
 Parisienne Thorofare,99,99
-"Red Door, The",99,99
+"Red Door, The",99,100
 Rick's Tricks,100,100
 Ow,101,101
-"Pesky Serpent, The",101,101
+"Pesky Serpent, The",101,102
 Pirouette,102,102
 Popo,103,103
-Pot Luck,103,103
+Pot Luck,103,104
 Prodefunctus,104,104
 Powder Puff,105,105
-Quasimado,105,105
+Quasimado,105,106
 Short Stop,106,106
-Ragamuffin,107,107
+Ragamuffin,107,108
 Rubberneck,107,107
 Something For Lisa,108,108
 Salute To Charlie Christian,109,109
-Seaside,109,109
+Seaside,109,110
 Sonny Side,110,110
 Prime Rib,111,111
-Rocker,111,111
+Rocker,111,112
 Swedish Pastry,112,112
-Russ job,113,113
-Rustic Hop,113,113
+Russ Job,113,113
+Rustic Hop,113,114
 Scrapple The Apple,114,114
-Local 802 Blues,115,115
-Local Blues,115,115
+Local 802 Blues,115,116
 Shank's Pranks,115,115
 Soft Shoe,116,116
-Signal,117,117
+Signal,117,118
 Si Si,118,118
 Spontaneous Combustion,118,118
 Sleepy Bop,119,119
-So Sorry Please,119,119
+So Sorry Please,119,120
 Swedish Schnapps,120,120
 Sextet,121,121
-Sonny Speaks,121,121
+Sonny Speaks,121,122
 "Squirrel, The",122,122
 Swing House,123,124
 Split Kick,125,125
 Tommyhawk,126,126
 Surf Ride,127,127
-Tahiti,127,127
+Tahiti,127,128
 Tickle Toe,128,128
 Summer Setting,129,129
-Swinging The Blues,129,129
+Swinging The Blues,129,130
 Swing Until The Girls Come Home,130,130
 That's What I'm Talking About,130,130
 Sticks And Stems,131,131
-Taps Miller,131,131
+Taps Miller,131,132
 Trumpet. Blues,132,132
 Thriving On A Riff,133,133
 Turnstile,133,134
+Meet Mr. Gordon,134,134
 Tasty Pudding,135,135
-"Theme, The",135,135
+"Theme, The",135,136
 This Reminds Me Of You,136,136
 Tootsie Roll,137,137
 Walkin' Shoes,137,138
+52nd St. Theme,138,138
 Tiny Capers,139,139
-Topsy,139,139
+Topsy,139,140
 Trickleydidlier,140,140
 Tamalpais,141,141
-Travisimo,141,141
+Travisimo,141,142
 Wee-Dot,142,142
-Meet Mr. Gordon,143,143
+# Meet Mr. Gordon,143,143
 Walk Don't Run,143,143
-Western Reunion,143,143
+Western Reunion,143,144
 Wind Bag,144,144
 Westwood Walk,145,145
-When Lights Are Low,145,145
+When Lights Are Low,145,146
 "Wind, The",146,146
 Yardbird Suite,147,147
-Yes Yes Honey,147,147
+Yes Yes Honey,147,148
 Yo Yo,148,148
+Visa,149,149
 Whose Blues,149,149
 St. Thomas,150,150
 Valse Hot,150,150
-Airegin,151,151
+Airegin,151,152
 Blue Seven,152,152
 Blues By Five,152,152
 Another Kind Of Soul,153,153
-Back Talk,153,153
+Back Talk,153,154
 Bimini,154,154
 Beach-Wise,155,155
-Before And After,155,155
+Before And After,155,156
 Bisquit Mix,156,156
 Blue Haze,157,157
 Blues In A Cold Water Flat,157,157
-Blues The Most,157,157
+Blues The Most,157,158
 Boardwalk,158,158
 Blues In The Closet,159,159
 Boomerang,160,160
 Bop City,161,161
-Bright Blues,161,161
+Bright Blues,161,162
 Captain Ahab,162,162
 Circling The Blues,162,162
 Caribbean Cutie,163,163
-Chuckles,163,163
+Chuckles,163,164
 Cruising,164,164
-Cool Cat On A Hot Tin Roof,165,165
+Cool Cat On A Hot Tin Roof,165,166
 Creepin' In,166,166
 Cooling It,167,167
-Crazeology,167,167
+Crazeology,167,168
 Criss Cross,168,168
 Debbie,169,169
-Digits,169,169
+Digits,169,170
 Doggin' Around,170,170
 Don't Argue,171,171
-Doodlin,171,171
+Doodlin',171,172
 Down For Double,172,172
 Doin' The Thing,173,173
 Down Tempo,173,173
-Duff,173,173
+Duff,173,174
 Frank 'N Earnest,174,174
 East Coast Outpost,175,175
-Edie McLin,175,175
+Edie McLin,175,176
 El Yorke,176,176
 Feelin' Fine,176,176
 Eronel,177,177
-Gerry's Blues,177,177
+Gerry's Blues,177,178
 Groovus Mentus,178,178
 Guatemala,178,178
 Gina,179,179
-Hankerin,179,179
+Hankerin,179,180
 Hello,180,180
 Hayseed,181,181
 Hip Bones,181,182
 Hippy,183,183
-In A Cello Mood,183,183
+In A Cello Mood,183,184
 Jackleg,184,184
 I Remember Duke,185,185
-Jolly Jumps In,185,185
-Jeanie,186,186
+Jolly Jumps In,185,186
+# Jeanie,186,186
 "Little Taste, A",186,186
 Jam For Your Bread,187,187
-Jolly Lodger,187,187
+Jolly Lodger,187,188
 Lillie,188,188
 Lands End,189,189
-Martians Go Home,189,189
+Martians Go Home,189,190
 Minor's Holiday,190,190
 Lonely Dreams,191,191
-Michele's Meditation,191,191
+Michele's Meditation,191,192
 Nutty Pine,192,192
 Midgets,193,193
-Miss Jackies Delight,193,193
+Miss Jackies Delight,193,194
 Misterioso,193,193
 Monti Celli,194,194
 No.251,195,195
-Oblivion,195,195
+Oblivion,195,196
 Off Minor,196,196
 Not Really The Blues,197,197
-Off To The Races,197,197
+Off To The Races,197,198
 Oh Play That Thing,198,198
 On The Scene,199,199
 One For Daddy-O,199,199
 Palermo Walk,200,200
 Paul's Pal,200,200
 Patti-Cake,201,201
-Pernod,201,201
+Pernod,201,202
 Pete's Meat,202,202
 Rattler's Groove,203,203
 Serenade To A Bus Seat,204,204
 Riviera,205,205
 Room 608,206,206
 Pimlico,207,207
-Sam's Tune,207,207
+Sam's Tune,207,208
 Senor Blues,208,208
 Section Blues,209,209
-Sermonette,209,209
+Sermonette,209,210
 Silverware,210,210
 Solar,211,211
-Spectacular,211,211
+Spectacular,211,212
 Stop Time,212,212
 Sudwest Funk,212,212
-"Fat Man, The",213,213
+"Fat Man, The",213,214
 Sweet Clifford,213,213
 Tribute To Brownie,214,214
 Tune Up,215,215

--- a/Library.csv
+++ b/Library.csv
@@ -2,7 +2,7 @@ Algo Bueno,5,5
 Au Privave,5,6
 Boo Boo Be Doop,6,6
 "Dandy Line, A",7,7
-"Night In Tunesia, A",7,8
+"Night In Tunisia, A",7,8
 An Oscar For Treadwell,8,8
 Batter Up,9,10
 Bunko,10,10


### PR DESCRIPTION
Mostly 2nd page number fixes.
Some title fixes.
Commented lines didn't exist in my copy. 52nd St Theme actually did, but with number and on a later page. Defaulted to "as displayed in PDF" as guideline.